### PR TITLE
fix: update mock household type in DayContextForm tests

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -37,8 +37,10 @@ All new functionality **must** be covered by appropriate tests:
 - `tests/steps/` — Playwright BDD step definitions
 - `tests/support/` — Test fixtures and helpers
 
-## Pull Request Requirements
+## Branching & Pull Requests
 
+- **Always work in a new branch** — never commit directly to `main`. Create a descriptive feature branch (e.g., `feat/number-stepper`, `fix/swipe-dismiss`) before making changes.
+- **Create a Pull Request** for every change. Push the branch and open a PR against `main`.
 - **Screenshots are required** for any PR that adds or changes UI functionality. Capture at mobile viewport (390×844) using Playwright or browser dev tools.
 - Use the PR template at `.github/PULL_REQUEST_TEMPLATE.md`.
 - Include a Screenshots section with images showing the new/changed views.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -44,6 +44,7 @@ All new functionality **must** be covered by appropriate tests:
 - **Screenshots are required** for any PR that adds or changes UI functionality. Capture at mobile viewport (390×844) using Playwright or browser dev tools.
 - Use the PR template at `.github/PULL_REQUEST_TEMPLATE.md`.
 - Include a Screenshots section with images showing the new/changed views.
+- **Verify CI passes** — after pushing, poll the PR's check runs (lint, test) until they complete. If any check fails, read the job logs, fix the issue, and push again. Do not consider the task done until all checks are green.
 
 ## Conventions
 

--- a/src/components/calendar/DayContextForm.test.tsx
+++ b/src/components/calendar/DayContextForm.test.tsx
@@ -28,12 +28,12 @@ const mockHousehold = {
   id: 'h1',
   name: 'Test',
   alias: null,
-  owner_id: 'u1',
   default_adults: 2,
   default_children: 1,
   default_babies: 0,
+  public_share_token: null,
+  created_by: null,
   created_at: '',
-  invite_code: null,
 }
 
 function createWrapper() {


### PR DESCRIPTION
## Summary
Fixes TypeScript build errors in `DayContextForm.test.tsx` — the mock household object was missing `public_share_token` and `created_by` fields and had stale `owner_id`/`invite_code` fields.

Also adds branching & CI check instructions to copilot-instructions.md.

## Screenshots
N/A — no UI changes.